### PR TITLE
quark: update url and hash

### DIFF
--- a/bucket/quarkclouddrive.json
+++ b/bucket/quarkclouddrive.json
@@ -3,8 +3,8 @@
     "description": "夸克网盘",
     "homepage": "https://pan.quark.cn/",
     "license": "Proprietary",
-    "url": "https://pdds.quark.cn/download/stfile/yy65y8z68yz4y282i/QuarkCloudDrive_v3.23.2_release_(Build2384776-20250822102933).exe",
-    "hash": "4c04168ec7b259b16fadf99daae1af61f938e28d85e52ac567328d481c234776",
+    "url": "https://pdds.quark.cn/download/stfile/hhnmhphokhilhjpjc/QuarkCloudDrive_v3.23.2_release_(Build2383348-20250821173039).exe",
+    "hash": "13FD42B7B04AE220785082E5D87A4450A7C23192A22CDADA9FCF9865A7C27056",
     "innosetup": true,
     "shortcuts": [
         [


### PR DESCRIPTION
修复了quark网盘下载链接失效的问题