### PR TITLE
添加 QuickBib 配置文件

### DIFF
--- a/bucket/quickbib.json
+++ b/bucket/quickbib.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.5.1",
+    "description": "Get BibTeX from a DOI — fast",
+    "homepage": "https://archisman-panigrahi.github.io/QuickBib/",
+    "license": "GPL-3.0-only",
+    "url": "https://github.com/archisman-panigrahi/QuickBib/releases/download/v0.5.1/QuickBib-Installer-0.5.1.exe",
+    "hash": "a41304a4ab88e786fe69cafe847e532f3f69340a0315421404ba90e1a79323fa",
+    "installer": {
+        "script": [
+            "Expand-7ZipArchive \"$dir\\$fname\" \"$dir\\\" -Removal",
+            "# 根据解压后的内容查找实际的可执行文件",
+            "$exeFiles = @(Get-ChildItem -Path \"$dir\" -Recurse -Name \"*.exe\" | Where-Object { $_ -match \"QuickBib\" -and $_ -notmatch \"uninst\" })",
+            "if ($exeFiles.Count -gt 0) {",
+            "    $actualExe = $exeFiles[0]",
+            "    if ($actualExe -ne 'QuickBib.exe') {",
+            "        Copy-Item \"$dir\\$actualExe\" \"$dir\\QuickBib.exe\"",
+            "    }",
+            "} else {",
+            "    throw \"Could not locate QuickBib executable after extraction\"",
+            "}"
+        ]
+    },
+    "shortcuts": [
+        [
+            "QuickBib.exe",
+            "QuickBib"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/archisman-panigrahi/QuickBib"
+    },
+    "autoupdate": {
+        "url": "https://github.com/archisman-panigrahi/QuickBib/releases/download/v$version/QuickBib-Installer-$version.exe"
+    }
+}


### PR DESCRIPTION
增加 QuickBib 的配置文件，QuickBib 是一款跨平台实用程序，用于[doi2bib3](https://github.com/archisman-panigrahi/doi2bib3)获取 DOI、arXiv 标识符以及文章标题的 BibTeX 代码。它既可以作为图形用户界面 (GUI) 应用使用，也可以作为命令行界面 (CLI) 使用。非常适合用于科研工作流程、论文撰写和自动化