### PR TITLE
增加 QuickBib 的配置文件，上次检查没通过

### DIFF
--- a/bucket/quickbib.json
+++ b/bucket/quickbib.json
@@ -34,6 +34,11 @@
         "github": "https://github.com/archisman-panigrahi/QuickBib"
     },
     "autoupdate": {
-        "url": "https://github.com/archisman-panigrahi/QuickBib/releases/download/v$version/QuickBib-Installer-$version.exe"
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/archisman-panigrahi/QuickBib/releases/download/v$version/QuickBib-Installer-$version.exe"
+            }
+        }
     }
+    
 }


### PR DESCRIPTION
增加 QuickBib 的配置文件，QuickBib 是一款跨平台实用程序，用于[doi2bib3](https://github.com/archisman-panigrahi/doi2bib3)获取 DOI、arXiv 标识符以及标题的 BibTeX 代码。它既可以作为图形用户界面 (GUI) 应用使用，也可以作为命令行界面 (CLI)。非常适合科研工作流程、论文撰写和自动化